### PR TITLE
Receiving the test runner context

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 var Q = require('q');
 
+/**
+ * Chai-Mugshot Plugin
+ *
+ * @param mugshot - Mugshot instance
+ * @param testRunnerCtx - Context of the test runner where the assertions are
+ *    done
+ */
 module.exports = function(mugshot, testRunnerCtx) {
   return function(chai) {
     var Assertion = chai.Assertion;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var Q = require('q');
 
-module.exports = function(mugshot) {
+module.exports = function(mugshot, testRunnerCtx) {
   return function(chai) {
     var Assertion = chai.Assertion;
 
@@ -25,6 +25,10 @@ module.exports = function(mugshot) {
           if (error) {
             deferred.reject(error);
           } else {
+            if (testRunnerCtx !== undefined) {
+              testRunnerCtx.result = result;
+            }
+
             try {
               _this.assert(result, msg.affirmative, msg.negative);
               deferred.resolve();

--- a/test/test.js
+++ b/test/test.js
@@ -23,7 +23,7 @@ function cleanUp() {
     try {
       fs.unlinkSync(paths[i]);
     } catch(error) {
-      if (error.code != 'ENOENT') {
+      if (error.code !== 'ENOENT') {
         throw error;
       }
     }
@@ -32,7 +32,7 @@ function cleanUp() {
   try {
     fs.rmdirSync(dir);
   } catch(error) {
-    if (error.code != 'ENOENT') {
+    if (error.code !== 'ENOENT') {
       throw error;
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -121,9 +121,7 @@ describe('Chai-Mugshot Plugin', function() {
 
     it('should put the result on the provided object', function() {
       return expect(withSelector).to.be.identical.then(function() {
-        expect(testRunnerCtx).to.have.ownProperty('result').and.to.deep.equal({
-          result: true
-        });
+        expect(testRunnerCtx).to.have.ownProperty('result');
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -112,6 +112,22 @@ describe('Chai-Mugshot Plugin', function() {
       .rejectedWith(AssertionError);
   });
 
+  describe('Test Runner Context', function() {
+    var testRunnerCtx = {};
+
+    before(function() {
+      chai.use(chaiMugshot(mugshot, testRunnerCtx));
+    });
+
+    it('should put the result on the provided object', function() {
+      return expect(withSelector).to.be.identical.then(function() {
+        expect(testRunnerCtx).to.have.ownProperty('result').and.to.deep.equal({
+          result: true
+        });
+      });
+    });
+  });
+
   after(function() {
     cleanUp();
     return wdioInstance.end();


### PR DESCRIPTION
## Need

```gherkin
As a developer
I need to have access to some data in the test runner reporter
So that I can present it further to the user
```

## Deliverables

Available data in the reporter.

## Solution

The solution is to pass in the `this object`, (i.e the test runner context), to the plugin, so that the plugin will put,  the [result from Mugshot](https://github.com/uberVU/mugshot/issues/42) on it.

```js
module.exports = function(mugshot, testRunner) {
  return function(chai) {
    ...
  }
};
```

[Here](https://github.com/uberVU/chai-mugshot/blob/4ed55c774817a0dbfea993cf4045d66008f18638/index.js#L28) in the try-catch, simply put the result on the test runner.

```js
if (testRunner !== undefined) {
  testRunner.result = result;
}
```

Of course the `use` of the `test runner` will be `optional`.