### PR TITLE
Refactoring tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -83,36 +83,46 @@ describe('Chai-Mugshot Plugin', function() {
     });
   });
 
-  it('should be rejected if mugshot fails', function() {
+  it('should be rejected with Error if Mugshot fails', function() {
     return expect(expect(brokenSelector).to.be.identical).to.be
       .rejectedWith(Error);
   });
 
   describe('No baseline', function() {
-    it('should not throw if there is no previous baseline', function() {
-      fs.unlinkSync(path.join(dir, name + ext));
+    beforeEach(function() {
+      cleanUp();
+    });
 
+    it('should be fulfilled if expected to be identical', function() {
       return expect(expect(withSelector).to.be.identical).to.be.fulfilled;
+    });
+
+    it('should be rejected with AssertionError if expected to not be identical',
+       function() {
+      return expect(expect(withSelector).to.not.be.identical).to.be
+        .rejectedWith(AssertionError);
     });
   });
 
   describe('No differences', function() {
-    it('should not throw if there are no differences', function() {
+    it('should be fullfilled if expected to be identical', function() {
       return expect(expect(withSelector).to.be.identical).to.be.fulfilled;
     });
 
-    it('should throw error if there are differences', function() {
+    it('should be rejected with AssertionError if expected to not be identical',
+       function() {
       return expect(expect(withSelector).to.not.be.identical).to.be
         .rejectedWith(AssertionError);
     });
   });
 
   describe('With differences', function() {
-    it('should not throw if there are differences', function() {
+    it('should be fulfilled if expected to not be identical', function() {
       return expect(expect(noSelector).to.not.be.identical).to.be.fulfilled;
     });
 
-    it('should throw if there are no differences', function() {
+    it('should be rejected with AssertionError if expected to be identical',
+       function() {
       return expect(expect(noSelector).to.be.identical).to.be
         .rejectedWith(AssertionError);
     });

--- a/test/test.js
+++ b/test/test.js
@@ -88,28 +88,34 @@ describe('Chai-Mugshot Plugin', function() {
       .rejectedWith(Error);
   });
 
-  it('should not throw if there is no previous baseline', function() {
-    fs.unlinkSync(path.join(dir, name + ext));
+  describe('No baseline', function() {
+    it('should not throw if there is no previous baseline', function() {
+      fs.unlinkSync(path.join(dir, name + ext));
 
-    return expect(expect(withSelector).to.be.identical).to.be.fulfilled;
+      return expect(expect(withSelector).to.be.identical).to.be.fulfilled;
+    });
   });
 
-  it('should not throw if there are no differences', function() {
-    return expect(expect(withSelector).to.be.identical).to.be.fulfilled;
+  describe('No differences', function() {
+    it('should not throw if there are no differences', function() {
+      return expect(expect(withSelector).to.be.identical).to.be.fulfilled;
+    });
+
+    it('should throw error if there are differences', function() {
+      return expect(expect(withSelector).to.not.be.identical).to.be
+        .rejectedWith(AssertionError);
+    });
   });
 
-  it('should throw error if there are differences', function() {
-    return expect(expect(withSelector).to.not.be.identical).to.be
-      .rejectedWith(AssertionError);
-  });
+  describe('With differences', function() {
+    it('should not throw if there are differences', function() {
+      return expect(expect(noSelector).to.not.be.identical).to.be.fulfilled;
+    });
 
-  it('should not throw if there are differences', function() {
-    return expect(expect(noSelector).to.not.be.identical).to.be.fulfilled;
-  });
-
-  it('should throw if there are no differences', function() {
-    return expect(expect(noSelector).to.be.identical).to.be
-      .rejectedWith(AssertionError);
+    it('should throw if there are no differences', function() {
+      return expect(expect(noSelector).to.be.identical).to.be
+        .rejectedWith(AssertionError);
+    });
   });
 
   describe('Test Runner Context', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -46,10 +46,10 @@ describe('Chai-Mugshot Plugin', function() {
         name: name,
         selector: 'anything'
       },
-      noSelector = {
+      differencesSelector = {
         name: name
       },
-      withSelector = {
+      noDifferencesSelector = {
         name: name,
         selector: '#rectangle'
       },
@@ -74,7 +74,7 @@ describe('Chai-Mugshot Plugin', function() {
   beforeEach(function(done) {
     cleanUp();
 
-    mugshot.test(withSelector, function(error) {
+    mugshot.test(noDifferencesSelector, function(error) {
       if (error) {
         throw error;
       }
@@ -94,36 +94,39 @@ describe('Chai-Mugshot Plugin', function() {
     });
 
     it('should be fulfilled if expected to be identical', function() {
-      return expect(expect(withSelector).to.be.identical).to.be.fulfilled;
+      return expect(expect(noDifferencesSelector).to.be.identical).to.be
+        .fulfilled;
     });
 
     it('should be rejected with AssertionError if expected to not be identical',
        function() {
-      return expect(expect(withSelector).to.not.be.identical).to.be
+      return expect(expect(noDifferencesSelector).to.not.be.identical).to.be
         .rejectedWith(AssertionError);
     });
   });
 
   describe('No differences', function() {
     it('should be fullfilled if expected to be identical', function() {
-      return expect(expect(withSelector).to.be.identical).to.be.fulfilled;
+      return expect(expect(noDifferencesSelector).to.be.identical).to.be
+        .fulfilled;
     });
 
     it('should be rejected with AssertionError if expected to not be identical',
        function() {
-      return expect(expect(withSelector).to.not.be.identical).to.be
+      return expect(expect(noDifferencesSelector).to.not.be.identical).to.be
         .rejectedWith(AssertionError);
     });
   });
 
   describe('With differences', function() {
     it('should be fulfilled if expected to not be identical', function() {
-      return expect(expect(noSelector).to.not.be.identical).to.be.fulfilled;
+      return expect(expect(differencesSelector).to.not.be.identical).to.be
+        .fulfilled;
     });
 
     it('should be rejected with AssertionError if expected to be identical',
        function() {
-      return expect(expect(noSelector).to.be.identical).to.be
+      return expect(expect(differencesSelector).to.be.identical).to.be
         .rejectedWith(AssertionError);
     });
   });
@@ -136,7 +139,7 @@ describe('Chai-Mugshot Plugin', function() {
     });
 
     it('should put the result on the provided object', function() {
-      return expect(withSelector).to.be.identical.then(function() {
+      return expect(noDifferencesSelector).to.be.identical.then(function() {
         expect(testRunnerCtx).to.have.ownProperty('result');
       });
     });


### PR DESCRIPTION
## Need

```gherkin
As a developer
I need to have clear and readable tests
So that I can understand what they are testing
```

## Deliverables
More accurate description for tests.

## Solution

Should wrap some tests into `describes`:

* this [2 tests](https://github.com/uberVU/chai-mugshot/blob/4ed55c774817a0dbfea993cf4045d66008f18638/test/test.js#L97-L104) into a describe with description `No differences`.

* this other [2 tests](https://github.com/uberVU/chai-mugshot/blob/master/test/test.js#L106-L113) into a describe with description `With differences`

Substitute some vars:

* `%s/withSelector/noDifferencesSelector`
* `%s/noSelector/DifferencesSelector`

Update some descriptions.