### PR TITLE
Fix linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function(mugshot, testRunnerCtx) {
             try {
               _this.assert(result, msg.affirmative, msg.negative);
               deferred.resolve();
-            } catch(error) {
+            } catch (error) {
               deferred.reject(error);
             }
           }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "chai-as-promised": "^5.1.0",
-    "eslint": "^1.2.1",
+    "eslint": "1.4.3",
     "mocha": "^2.3.0",
     "mugshot": "0.0.1",
     "phantomjs": "^1.9.18",

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ function cleanUp() {
   for (var i = 0; i < paths.length; i++) {
     try {
       fs.unlinkSync(paths[i]);
-    } catch(error) {
+    } catch (error) {
       if (error.code !== 'ENOENT') {
         throw error;
       }
@@ -31,7 +31,7 @@ function cleanUp() {
 
   try {
     fs.rmdirSync(dir);
-  } catch(error) {
+  } catch (error) {
     if (error.code !== 'ENOENT') {
       throw error;
     }


### PR DESCRIPTION
ESLint package got a bump and the [space-after-keywords](http://eslint.org/docs/rules/space-after-keywords) rule was catching some new errors.