### PR TITLE
Assert the isEqual prop of Mugshot result

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function(mugshot, testRunnerCtx) {
             }
 
             try {
-              _this.assert(result, msg.affirmative, msg.negative);
+              _this.assert(result.isEqual, msg.affirmative, msg.negative);
               deferred.resolve();
             } catch (error) {
               deferred.reject(error);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai-as-promised": "^5.1.0",
     "eslint": "1.4.3",
     "mocha": "^2.3.0",
-    "mugshot": "0.0.1",
+    "mugshot": "0.2.0",
     "phantomjs": "^1.9.18",
     "webdriverio": "^3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "q": "^1.4.1"
   },
   "peerDependencies": {
-    "chai": "^3.2.0"
+    "chai": "^3.2.0",
+    "mugshot": "0.2.0"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
## Need

```gherkin
As a user
I need to know quick if my tests are passing
So that I can fix bugs or logic errors
```

## Deliverables

Better assertion.

## Solution

We must `assert` the `isEqual` property of `Mugshot's result` object. Not the [entire object](https://github.com/uberVU/chai-mugshot/blob/93ba656885ef05bfac69fd12b9844a46acccb186/index.js#L40)!